### PR TITLE
ci: add docs.rs build workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,6 +7,12 @@ on:
       - "**/Cargo.toml"
       - "**/Cargo.lock"
       - ".github/workflows/check.yml"
+  pull_request:
+    paths:
+      - "**.rs"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - ".github/workflows/check.yml"
 
 jobs:
   lint:
@@ -39,3 +45,19 @@ jobs:
 
       - name: rustfmt
         run: cargo fmt --all -- --check
+
+  docs-rs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: dtolnay/install@cargo-docs-rs
+
+      - name: run cargo-docs-rs
+        env:
+          RUSTDOCFLAGS: -Dwarnings
+        run: cargo docs-rs

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,6 +2,7 @@ name: check
 on:
   workflow_dispatch:
   push:
+    branches: [main]
     paths:
       - "**.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -51,7 +51,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: aarch64-apple-darwin
 
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: test
 on:
   workflow_dispatch:
   push:
+    branches: [main]
     paths:
       - "**.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,12 @@ on:
       - "**/Cargo.toml"
       - "**/Cargo.lock"
       - ".github/workflows/test.yml"
+  pull_request:
+    paths:
+      - "**.rs"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - ".github/workflows/test.yml"
 
 jobs:
   tests:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ license = "MIT"
 [workspace]
 members = [".", "crates/*"]
 
+[package.metadata.docs.rs]
+default-target = "aarch64-apple-darwin"
+
 [target.'cfg(target_os = "windows")'.dependencies]
 flume = "0.11.0"
 windows-interface = "0.56.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,10 +12,10 @@ pub struct Watcher {
 impl Watcher {
     /// Watches for all window events.
     ///
-    /// To stop watching events, drop the returned [Watcher](Watcher).
+    /// To stop watching events, drop the returned [Watcher].
     ///
     /// Note, this function will begin listening to new events. To access a list of
-    /// existing windows, call [`Watcher::iter_windows`](Watcher::iter_windows).
+    /// existing windows, call [`iter_windows`].
     #[inline]
     pub fn new() -> Result<Watcher, WindowError> {
         Ok(Watcher {


### PR DESCRIPTION
Adds a workflow to build docs.rs. Also changes the default docs.rs build target to macOS since this crate does not support Linux. Workflows will now run on PRs too.